### PR TITLE
Cerulean sky timestamps

### DIFF
--- a/gotify_tray/gotify/models.py
+++ b/gotify_tray/gotify/models.py
@@ -1,4 +1,5 @@
 import datetime
+from dateutil.parser import isoparse
 import logging
 from typing import List, Optional
 
@@ -47,15 +48,8 @@ class GotifyMessageModel(AttributeDict):
     title: Optional[str] = None
 
     def __init__(self, d: dict, *args, **kwargs):
-        s = (
-            d["date"].split(".")[0]  # date
-            + "."
-            + d["date"].split(".")[1][:6]  # ms
-            + "+"
-            + d["date"].split("+")[-1]  # timezone
-        )
         d.update(
-            {"date": datetime.datetime.fromisoformat(s).astimezone(local_timezone)}
+            {"date": isoparse(d["date"]).astimezone(local_timezone)}
         )
         super(GotifyMessageModel, self).__init__(d, *args, **kwargs)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.27.1
 websocket-client==1.2.3
 pyqt6==6.2.3
+python-dateutil==2.8.2


### PR DESCRIPTION
As described in issue #1 , this is a solution to handle the rfc3339 timestamps that gotify might and will serve depending on its host and the timezone it derives from its host.