### PR TITLE
pop window on current desktop if window was visible on another desktop

### DIFF
--- a/gotify_tray/gui/widgets/MainWindow.py
+++ b/gotify_tray/gui/widgets/MainWindow.py
@@ -152,6 +152,8 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         )
         self.show()
         self.activateWindow()
+        # pops on current desktop if window was visible on another desktop
+        self.raise_()
 
     def link_callbacks(self):
         self.pb_refresh.clicked.connect(self.refresh.emit)


### PR DESCRIPTION
if window was already shown on a desktop and the tray was clicked, the window would not pop