### PR TITLE
draft: set a new icon icon when there are new messages

### DIFF
--- a/gotify_tray/gui/widgets/MainWindow.py
+++ b/gotify_tray/gui/widgets/MainWindow.py
@@ -69,6 +69,10 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
         self.link_callbacks()
 
+        # set refresh shortcut (usually ctrl-r)
+        # unfortunately this cannot be done with designer
+        self.pb_refresh.setShortcut(QtGui.QKeySequence(QtGui.QKeySequence.StandardKey.Refresh))
+
     def set_icons(self):
         # Set button icons
         self.pb_refresh.setIcon(QtGui.QIcon(get_theme_file("refresh.svg")))


### PR DESCRIPTION
the new icon is shown:
- on startup, if there are notifications
- when new messages are received

the "new messages" icon is cleared when the main window is displayed

the icon is ugly and my implementation is not optimal i believe, but it's a draft to first discuss the idea to have your opinion